### PR TITLE
Rename target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,4 +24,4 @@ Sources/OrderedSet/OrderedSet.swift:
 Tests/OrderedSetTests/OrderedSetTests.swift:
 	@echo $@
 	@echo "// From $(TEST_URL)" > $@
-	@curl -L $(TEST_URL) >> $@
+	@curl -L $(TEST_URL) | sed 's/TSCBasic/OrderedSet/g' | sed '/^typealias/ d'  >> $@

--- a/OrderedSet.swift.podspec
+++ b/OrderedSet.swift.podspec
@@ -1,6 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name = 'OrderedSet.swift'
-  spec.version = '0.1.0'
+  spec.module_name = 'OrderedSet'
+  spec.version = '0.1.1'
   spec.summary = 'Ordered Set implementation for Swift'
   spec.homepage = 'https://github.com/cocodelabs/OrderedSet'
   spec.license = { :type => 'CUSTOM', :file => 'LICENSE.txt' }

--- a/Package.swift
+++ b/Package.swift
@@ -6,13 +6,13 @@ let package = Package(
   products: [
     .library(
         name: "OrderedSet",
-        targets: ["TSCBasic"]),
+        targets: ["OrderedSet"]),
   ],
   targets: [
-    .target(name: "TSCBasic", path: "Sources/OrderedSet"),
+    .target(name: "OrderedSet", path: "Sources/OrderedSet"),
     .testTarget(
       name: "OrderedSetTests",
-      dependencies: ["TSCBasic"]
+      dependencies: ["OrderedSet"]
     ),
   ]
 )

--- a/Tests/OrderedSetTests/OrderedSet+CocodeTests.swift
+++ b/Tests/OrderedSetTests/OrderedSet+CocodeTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+
+import OrderedSet
+
+class OrderedSetCocodeTests: XCTestCase {
+    func testAppendSequence() {
+        var set = OrderedSet<String>()
+        XCTAssertTrue(set.isEmpty)
+        XCTAssertEqual(set.contents, [])
+
+        XCTAssertTrue(set.append(["one", "two", "three"]))
+
+        XCTAssertFalse(set.isEmpty)
+        XCTAssertEqual(set.count, 3)
+        XCTAssertEqual(set[0], "one")
+        XCTAssertEqual(set[1], "two")
+        XCTAssertEqual(set[2], "three")
+        XCTAssertEqual(set.contents, ["one", "two", "three"])
+
+        XCTAssertFalse(set.append(["one", "two"]))
+        XCTAssertFalse(set.append(["one", "two", "three"]))
+    }
+
+    func testAppendingSequence() {
+        let reference = OrderedSet(["one", "two", "three"])
+        let set = OrderedSet(["one"])
+
+        XCTAssertNotEqual(reference, set)
+        XCTAssertEqual(reference, set.appending(["two", "three"]))
+    }
+
+    func testSubtractSequence() {
+        var set = OrderedSet(["one", "two", "three"])
+
+        set.subtract(["two", "three"])
+
+        XCTAssertFalse(set.isEmpty)
+        XCTAssertEqual(set.count, 1)
+        XCTAssertEqual(set[0], "one")
+        XCTAssertEqual(set.contents, ["one"])
+    }
+
+    func testSubtractingSequence() {
+        let reference = OrderedSet(["one"])
+        let set = OrderedSet(["one", "two", "three"])
+
+        XCTAssertNotEqual(reference, set)
+        XCTAssertEqual(reference, set.subtracting(["two", "three"]))
+    }
+}

--- a/Tests/OrderedSetTests/OrderedSetTests.swift
+++ b/Tests/OrderedSetTests/OrderedSetTests.swift
@@ -55,49 +55,4 @@ class OrderedSetTests: XCTestCase {
         XCTAssertEqual(set.remove("Hello"), nil)
         XCTAssertEqual(set.remove("cool"), nil)
     }
-
-    func testAppendSequence() {
-        var set = OrderedSet<String>()
-        XCTAssertTrue(set.isEmpty)
-        XCTAssertEqual(set.contents, [])
-
-        XCTAssertTrue(set.append(["one", "two", "three"]))
-
-        XCTAssertFalse(set.isEmpty)
-        XCTAssertEqual(set.count, 3)
-        XCTAssertEqual(set[0], "one")
-        XCTAssertEqual(set[1], "two")
-        XCTAssertEqual(set[2], "three")
-        XCTAssertEqual(set.contents, ["one", "two", "three"])
-
-        XCTAssertFalse(set.append(["one", "two"]))
-        XCTAssertFalse(set.append(["one", "two", "three"]))
-    }
-
-    func testAppendingSequence() {
-        let reference = OrderedSet(["one", "two", "three"])
-        let set = OrderedSet(["one"])
-
-        XCTAssertNotEqual(reference, set)
-        XCTAssertEqual(reference, set.appending(["two", "three"]))
-    }
-
-    func testSubtractSequence() {
-        var set = OrderedSet(["one", "two", "three"])
-
-        set.subtract(["two", "three"])
-
-        XCTAssertFalse(set.isEmpty)
-        XCTAssertEqual(set.count, 1)
-        XCTAssertEqual(set[0], "one")
-        XCTAssertEqual(set.contents, ["one"])
-    }
-
-    func testSubtractingSequence() {
-        let reference = OrderedSet(["one"])
-        let set = OrderedSet(["one", "two", "three"])
-
-        XCTAssertNotEqual(reference, set)
-        XCTAssertEqual(reference, set.subtracting(["two", "three"]))
-    }
 }

--- a/Tests/OrderedSetTests/OrderedSetTests.swift
+++ b/Tests/OrderedSetTests/OrderedSetTests.swift
@@ -11,9 +11,8 @@
 
 import XCTest
 
-import TSCBasic
+import OrderedSet
 
-typealias OrderedSet = TSCBasic.OrderedSet
 
 class OrderedSetTests: XCTestCase {
     func testBasics() {


### PR DESCRIPTION
This PR renames the target from `TSCBasic` to `OrderedSet.swift`. This is necessary because the module name when installing this library with SPM or cocoapods was different. If a project uses SPM for CI test cases, but cocoapods for distribution, it would fail to compile on one of the two.